### PR TITLE
migrate set-output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         id: set-matrix
         run: |
           import json
+          import os
           perl = [
               '5.34',
               '5.32',
@@ -61,7 +62,8 @@ jobs:
               'include': includes
           }
           output = json.dumps(matrix, separators=(',', ':'))
-          print('::set-output name=matrix::{0}'.format(output))
+          with open(os.environ["GITHUB_OUTPUT"], 'a', encoding="utf-8") as f:
+            f.write('matrix={0}\n'.format(output))
         shell: python
 
   test:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/